### PR TITLE
feat: scaffold Next.js app structure

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.next/
+out/
+dist/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import './globals.css';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ru">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import Step3DPrototype from '../components/Step3DPrototype';
+
+export default function Home() {
+  return <Step3DPrototype />;
+}

--- a/components/Step3DPrototype.tsx
+++ b/components/Step3DPrototype.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useMemo, useState, type ElementType, type ReactNode } from "react";
 import { motion } from "framer-motion";
 import { Menu, X, ExternalLink, Share2, Pencil, Plus, Save, Trash2, Search } from "lucide-react";
@@ -334,7 +335,7 @@ function Articles({ items }:{ items:Article[] }){
               </div>
               <div className="flex items-center justify-between pt-2 text-xs text-neutral-600">
                 <span>{fmtDate(a.date)}</span>
-                <a className="inline-flex items-center gap-1 hover:underline" href={tgShareLink({ url: location.href + '#articles', text: a.title })} target="_blank" rel="noreferrer">
+                <a className="inline-flex items-center gap-1 hover:underline" href={tgShareLink({ url: (typeof window !== "undefined" ? window.location.href : "") + '#articles', text: a.title })} target="_blank" rel="noreferrer">
                   <Share2 size={14}/> Поделиться
                 </a>
               </div>
@@ -366,7 +367,7 @@ function Courses({ items }:{ items:Course[] }){
               <p className="text-sm text-neutral-700">{c.summary}</p>
               <div className="flex gap-2">
                 <Button as="a" href="#" className="hover:bg-black hover:text-white">Силлабус</Button>
-                <Button as="a" href={tgShareLink({ url: location.href + '#courses', text: c.title })} target="_blank" className="hover:bg-black hover:text-white"><Share2 size={14}/> Поделиться</Button>
+                <Button as="a" href={tgShareLink({ url: (typeof window !== "undefined" ? window.location.href : "") + '#courses', text: c.title })} target="_blank" className="hover:bg-black hover:text-white"><Share2 size={14}/> Поделиться</Button>
               </div>
             </div>
           </motion.div>
@@ -388,7 +389,7 @@ function Blog({ items }:{ items:Post[] }){
             </div>
             <div className="flex items-center justify-between gap-4 md:justify-end">
               <span className="text-xs text-neutral-600">{fmtDate(p.date)}</span>
-              <a className="inline-flex items-center gap-1 text-sm hover:underline" href={tgShareLink({ url: location.href + '#blog', text: p.title })} target="_blank" rel="noreferrer">
+              <a className="inline-flex items-center gap-1 text-sm hover:underline" href={tgShareLink({ url: (typeof window !== "undefined" ? window.location.href : "") + '#blog', text: p.title })} target="_blank" rel="noreferrer">
                 <Share2 size={14}/> В Telegram
               </a>
             </div>
@@ -414,7 +415,7 @@ function About(){
           </div>
           <div className="rounded-2xl border border-black p-3 text-sm text-neutral-700 bg-[rgba(0,0,0,0.02)]">
             <p className="mb-1 font-semibold">Виджет Telegram (встраивание постов)</p>
-            <p>Для продакшена подключите скрипт <code>https://telegram.org/js/telegram-widget.js</code> и используйте тег <code>&lt;div class="telegram-post" data-telegram-post="CHANNEL/POST_ID"&gt;</code>.</p>
+            <p>Для продакшена подключите скрипт <code>https://telegram.org/js/telegram-widget.js</code> и используйте тег <code>&lt;div class=&quot;telegram-post&quot; data-telegram-post=&quot;CHANNEL/POST_ID&quot;&gt;</code>.</p>
           </div>
         </div>
         <div className="overflow-hidden rounded-3xl border border-black">

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -10,21 +10,25 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@next/mdx": "14.2.5",
+    "framer-motion": "12.23.12",
+    "fuse.js": "7.0.0",
+    "lucide-react": "0.542.0",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "fuse.js": "7.0.0",
-    "@next/mdx": "14.2.5",
     "rehype-autolink-headings": "7.1.0",
     "rehype-slug": "6.0.0",
     "remark-gfm": "4.0.0"
   },
   "devDependencies": {
+    "@types/node": "24.3.0",
+    "@types/react": "19.1.12",
     "autoprefixer": "10.4.18",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.10",
-    "typescript": "5.5.4",
-    "eslint": "8.57.0",
-    "eslint-config-next": "14.2.5"
+    "typescript": "5.5.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- set up Next.js `app` directory with layout and home page
- move existing prototype into `components/Step3DPrototype` and enable client-only usage
- configure TypeScript, ESLint, and Tailwind globals; add missing dependencies

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b305d79d5083339787f03d3d173722