### PR TITLE
test: set up Jest and add sample Nav test

### DIFF
--- a/components/Step3DPrototype.tsx
+++ b/components/Step3DPrototype.tsx
@@ -150,7 +150,7 @@ function Section({ id, title, subtitle, children }:{ id:string; title:string; su
 // =============================
 // Navigation
 // =============================
-function Nav({ open, setOpen }:{ open:boolean; setOpen:(v:boolean)=>void }){
+export function Nav({ open, setOpen }:{ open:boolean; setOpen:(v:boolean)=>void }){
   const items = [
     { href: "#articles", label: "Статьи" },
     { href: "#courses", label: "Курсы" },

--- a/components/__tests__/Nav.test.tsx
+++ b/components/__tests__/Nav.test.tsx
@@ -1,0 +1,12 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Nav } from '../Step3DPrototype';
+
+describe('Nav', () => {
+  it('calls setOpen when toggle button is clicked', () => {
+    const setOpen = jest.fn();
+    const { getByRole } = render(<Nav open={false} setOpen={setOpen} />);
+    fireEvent.click(getByRole('button', { name: /toggle menu/i }));
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,11 @@
+import nextJest from 'next/jest';
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const config = {
+  testEnvironment: 'jest-environment-jsdom',
+};
+
+export default createJestConfig(config);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "export": "next export",
     "start": "npx serve out -l 3000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@next/mdx": "14.2.5",
@@ -22,13 +23,19 @@
     "remark-gfm": "4.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest": "^30.0.0",
     "@types/node": "24.3.0",
     "@types/react": "19.1.12",
     "autoprefixer": "10.4.18",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
+    "jest": "^30.1.1",
+    "jest-environment-jsdom": "^30.1.1",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.10",
+    "ts-node": "^10.9.2",
     "typescript": "5.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library configuration
- create example Nav component test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b308bd81d483338b67824c8f460280