### PR TITLE
Add static docs structure

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,33 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, #fdfdfd, #dbeafe);
+}
+
+.container {
+  padding: 3rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 1rem;
+  box-shadow: 0 1.5rem 3rem -1rem rgba(15, 23, 42, 0.25);
+  text-align: center;
+  max-width: 42rem;
+}
+
+h1 {
+  margin-bottom: 1rem;
+  font-size: clamp(2rem, 5vw, 3rem);
+  color: #1e293b;
+}
+
+p {
+  margin: 0;
+  color: #334155;
+  font-size: 1.125rem;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>R22 Lab Docs</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Добро пожаловать в документацию R22 Lab</h1>
+    <p>Эта страница предназначена для размещения статических материалов проекта.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a docs directory with a static index page for documentation
- include a starter stylesheet under docs/assets
- ensure GitHub Pages compatibility with a .nojekyll marker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce1f0d0bec8333b4d0896248eba30a